### PR TITLE
fix: add torch as build dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ __version__ = '1.3.1'
 url = 'https://github.com/rusty1s/pytorch_scatter'
 
 install_requires = []
-setup_requires = ['pytest-runner']
+setup_requires = ['pytest-runner', 'torch']
 tests_require = ['pytest', 'pytest-cov']
 
 setup(


### PR DESCRIPTION
Allows adding torch-scatter and torch in the same `requirements.txt` file.