### PR TITLE
solve deterministic problems of scatter_max

### DIFF
--- a/cpu/scatter.cpp
+++ b/cpu/scatter.cpp
@@ -37,6 +37,11 @@ void scatter_max(at::Tensor src, at::Tensor index, at::Tensor out,
                  for (i = 0; i < elems_per_row; i++) {
                    idx = index_data[i * index_stride];
                    if (src_data[i * src_stride] >= out_data[idx * out_stride]) {
+                     if (src_data[i * src_stride] == out_data[idx * out_stride]) {
+                        if (i > arg_data[idx * arg_stride])
+                          arg_data[idx * arg_stride] = i;
+                        continue;
+                     }
                      out_data[idx * out_stride] = src_data[i * src_stride];
                      arg_data[idx * arg_stride] = i;
                    }

--- a/cuda/scatter_kernel.cu
+++ b/cuda/scatter_kernel.cu
@@ -92,8 +92,11 @@ __global__ void arg_kernel(at::cuda::detail::TensorInfo<scalar_t, int64_t> src,
     IndexToScatterOffsets4<scalar_t, scalar_t, int64_t, Dims>::compute(
         i, dim, index, &indexOffset, src, &srcOffset, out, &outOffset, arg,
         &argOffset);
+    __syncthreads();
     if (src.data[srcOffset] == out.data[outOffset]) {
-      arg.data[argOffset] = (srcOffset / src.strides[dim]) % src.sizes[dim];
+      int64_t cur_id = (srcOffset / src.strides[dim]) % src.sizes[dim];
+      atomMax(&arg.data[argOffset], cur_id);
+     }
     }
   }
 }


### PR DESCRIPTION
currently, I found some person including me faced with reproductive problems due to arg_kernel of scatter max. So I modify the code to ensure arg kernel to be deterministic.
In detail, I use the atomicMax to ensure each arg index to be the largest index. However, this might increase the time cost