### PR TITLE
Fixed Driver Not Found Error in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ $ echo $CPATH
 >>> /usr/local/cuda/include:...
 ```
 
-Then run:
+Running in a docker container without nvidia driver, pytorch needs to evaluate the compute capabilities and fails. Ensure in this case that the compute capabilities are set in ENV TORCH_CUDA_ARCH_LIST
 
 ```
-pip install torch-scatter
+ENV TORCH_CUDA_ARCH_LIST = "6.0 6.1 7.2+PTX 7.5+PTX"
 ```
 
 If you are running into any installation problems, please create an [issue](https://github.com/rusty1s/pytorch_scatter/issues).


### PR DESCRIPTION
Pytorch is unable to evaluate nvidia compute capabilities in Docker container:
Solution:
```
Dockerfile ...

ARG TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX 7.5+PTX"

```
or 

```
export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX 7.5+PTX"
```
Error Message:
```
...
Error when building in Docker container:
Found no NVIDIA driver on your system. Please check that you
have an NVIDIA GPU and installed a driver from
http://www.nvidia.com/Download/index.aspx
...
```
Whole Message:
```
Collecting torch-scatter
  Downloading https://files.pythonhosted.org/packages/b8/c3/8bad887ffa55c86f120ef5ae252dc0e357b3bd956d9fbf45242bacc46290/torch_scatter-1.4.0.tar.gz
Building wheels for collected packages: torch-scatter
  Building wheel for torch-scatter (setup.py): started
  Building wheel for torch-scatter (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-xenlbljt/torch-scatter/setup.py'"'"'; __file__='"'"'/tmp/pip-install-xenlbljt/torch-scatter/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-ecrlxwab --python-tag cp36
       cwd: /tmp/pip-install-xenlbljt/torch-scatter/
  Complete output (105 lines):
  No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  creating build/lib.linux-x86_64-3.6/test
  copying test/test_multi_gpu.py -> build/lib.linux-x86_64-3.6/test
  copying test/test_forward.py -> build/lib.linux-x86_64-3.6/test
  copying test/test_max_min.py -> build/lib.linux-x86_64-3.6/test
  copying test/test_logsumexp.py -> build/lib.linux-x86_64-3.6/test
  copying test/__init__.py -> build/lib.linux-x86_64-3.6/test
  copying test/test_broadcasting.py -> build/lib.linux-x86_64-3.6/test
  copying test/utils.py -> build/lib.linux-x86_64-3.6/test
  copying test/test_backward.py -> build/lib.linux-x86_64-3.6/test
  copying test/test_std.py -> build/lib.linux-x86_64-3.6/test
  Running setup.py clean for torch-scatter
  creating build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/sub.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/logsumexp.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/max.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/div.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/__init__.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/add.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/mean.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/std.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/min.py -> build/lib.linux-x86_64-3.6/torch_scatter
  copying torch_scatter/mul.py -> build/lib.linux-x86_64-3.6/torch_scatter
  creating build/lib.linux-x86_64-3.6/torch_scatter/composite
  copying torch_scatter/composite/softmax.py -> build/lib.linux-x86_64-3.6/torch_scatter/composite
  copying torch_scatter/composite/__init__.py -> build/lib.linux-x86_64-3.6/torch_scatter/composite
  creating build/lib.linux-x86_64-3.6/torch_scatter/utils
  copying torch_scatter/utils/__init__.py -> build/lib.linux-x86_64-3.6/torch_scatter/utils
  copying torch_scatter/utils/ext.py -> build/lib.linux-x86_64-3.6/torch_scatter/utils
  copying torch_scatter/utils/gen.py -> build/lib.linux-x86_64-3.6/torch_scatter/utils
  running build_ext
  building 'torch_scatter.scatter_cpu' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/cpu
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.6/dist-packages/torch/include -I/usr/local/lib/python3.6/dist-packages/torch/include/torch/csrc/api/include -I/usr/local/lib/python3.6/dist-packages/torch/include/TH -I/usr/local/lib/python3.6/dist-packages/torch/include/THC -I/usr/include/python3.6m -c cpu/scatter.cpp -o build/temp.linux-x86_64-3.6/cpu/scatter.o -Wno-unused-variable -DVERSION_GE_1_3 -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=scatter_cpu -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
  x86_64-linux-gnu-g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.6/cpu/scatter.o -o build/lib.linux-x86_64-3.6/torch_scatter/scatter_cpu.cpython-36m-x86_64-linux-gnu.so
  building 'torch_scatter.scatter_cuda' extension
  creating build/temp.linux-x86_64-3.6/cuda
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.6/dist-packages/torch/include -I/usr/local/lib/python3.6/dist-packages/torch/include/torch/csrc/api/include -I/usr/local/lib/python3.6/dist-packages/torch/include/TH -I/usr/local/lib/python3.6/dist-packages/torch/include/THC -I/usr/local/cuda/include -I/usr/include/python3.6m -c cuda/scatter.cpp -o build/temp.linux-x86_64-3.6/cuda/scatter.o -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=scatter_cuda -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-xenlbljt/torch-scatter/setup.py", line 52, in <module>
      packages=find_packages(),
    File "/usr/local/lib/python3.6/dist-packages/setuptools/__init__.py", line 145, in setup
      return distutils.core.setup(**attrs)
    File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/usr/lib/python3/dist-packages/wheel/bdist_wheel.py", line 204, in run
      self.run_command('build')
    File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/usr/lib/python3.6/distutils/command/build.py", line 135, in run
      self.run_command(cmd_name)
    File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.6/dist-packages/setuptools/command/build_ext.py", line 84, in run
      _build_ext.run(self)
    File "/usr/local/lib/python3.6/dist-packages/Cython/Distutils/old_build_ext.py", line 186, in run
      _build_ext.build_ext.run(self)
    File "/usr/lib/python3.6/distutils/command/build_ext.py", line 339, in run
      self.build_extensions()
    File "/usr/local/lib/python3.6/dist-packages/torch/utils/cpp_extension.py", line 353, in build_extensions
      build_ext.build_extensions(self)
    File "/usr/local/lib/python3.6/dist-packages/Cython/Distutils/old_build_ext.py", line 195, in build_extensions
      _build_ext.build_ext.build_extensions(self)
    File "/usr/lib/python3.6/distutils/command/build_ext.py", line 448, in build_extensions
      self._build_extensions_serial()
    File "/usr/lib/python3.6/distutils/command/build_ext.py", line 473, in _build_extensions_serial
      self.build_extension(ext)
    File "/usr/local/lib/python3.6/dist-packages/setuptools/command/build_ext.py", line 205, in build_extension
      _build_ext.build_extension(self, ext)
    File "/usr/lib/python3.6/distutils/command/build_ext.py", line 533, in build_extension
      depends=ext.depends)
    File "/usr/lib/python3.6/distutils/ccompiler.py", line 574, in compile
      self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
    File "/usr/local/lib/python3.6/dist-packages/torch/utils/cpp_extension.py", line 269, in unix_wrap_compile
      "'-fPIC'"] + cflags + _get_cuda_arch_flags(cflags)
    File "/usr/local/lib/python3.6/dist-packages/torch/utils/cpp_extension.py", line 977, in _get_cuda_arch_flags
      capability = torch.cuda.get_device_capability()
    File "/usr/local/lib/python3.6/dist-packages/torch/cuda/__init__.py", line 328, in get_device_capability
      prop = get_device_properties(device)
    File "/usr/local/lib/python3.6/dist-packages/torch/cuda/__init__.py", line 334, in get_device_properties
      init()  # will define _get_device_properties and _CudaDeviceProperties
    File "/usr/local/lib/python3.6/dist-packages/torch/cuda/__init__.py", line 164, in init
      _lazy_init()
    File "/usr/local/lib/python3.6/dist-packages/torch/cuda/__init__.py", line 192, in _lazy_init
      _check_driver()
    File "/usr/local/lib/python3.6/dist-packages/torch/cuda/__init__.py", line 102, in _check_driver
      http://www.nvidia.com/Download/index.aspx""")
  AssertionError:
  Found no NVIDIA driver on your system. Please check that you
  have an NVIDIA GPU and installed a driver from
  http://www.nvidia.com/Download/index.aspx
  ----------------------------------------
  ERROR: Failed building wheel for torch-scatter
Failed to build torch-scatter
```