### PR TITLE
Fix: dim should be int

### DIFF
--- a/torch_scatter/utils/gen.py
+++ b/torch_scatter/utils/gen.py
@@ -8,7 +8,8 @@ import torch
 def maybe_dim_size(index, dim_size=None):
     if dim_size is not None:
         return dim_size
-    return index.max().item() + 1 if index.numel() > 0 else 0
+    dim = index.max().item() + 1 if index.numel() > 0 else 0
+    return int(dim)
 
 
 def broadcast(src, index, dim):


### PR DESCRIPTION
Otherwise it may error:

```python
     52         out_size[dim] = dim_size
     53         print(dim, dim_size)
---> 54         out = src.new_full(out_size, fill_value)
     55 
     56     return src, out, index, dim

TypeError: new_full(): argument 'size' must be tuple of ints, but found element of type float at pos 2
```