### PR TITLE
fix: use std::vector for dynamically sized array in gather.cpp and segment.cpp

### DIFF
--- a/cpu/gather.cpp
+++ b/cpu/gather.cpp
@@ -3,6 +3,8 @@
 #include "compat.h"
 #include "index_info.h"
 
+#include <vector>
+
 #define CHECK_CPU(x) AT_ASSERTM(!x.type().is_cuda(), #x " must be CPU tensor")
 
 at::Tensor gather_csr(at::Tensor src, at::Tensor indptr,
@@ -43,7 +45,7 @@ at::Tensor gather_csr(at::Tensor src, at::Tensor indptr,
     auto src_data = src.DATA_PTR<scalar_t>();
     auto out_data = out.DATA_PTR<scalar_t>();
 
-    scalar_t vals[K];
+    std::vector<scalar_t> vals(K);
     int64_t row_start, row_end;
     for (int n = 0; n < N; n++) {
       int offset = IndexPtrToOffset<int64_t>::get(n, indptr_info);
@@ -104,7 +106,7 @@ at::Tensor gather_coo(at::Tensor src, at::Tensor index,
     auto src_data = src.DATA_PTR<scalar_t>();
     auto out_data = out.DATA_PTR<scalar_t>();
 
-    scalar_t vals[K];
+    std::vector<scalar_t> vals(K);
     int64_t idx, next_idx;
     for (int e_1 = 0; e_1 < E_1; e_1++) {
       int offset = IndexToOffset<int64_t>::get(e_1 * E_2, index_info);

--- a/cpu/segment.cpp
+++ b/cpu/segment.cpp
@@ -3,6 +3,8 @@
 #include "compat.h"
 #include "index_info.h"
 
+#include <vector>
+
 #define CHECK_CPU(x) AT_ASSERTM(!x.type().is_cuda(), #x " must be CPU tensor")
 
 enum ReductionType { ADD, MEAN, MIN, MAX };
@@ -123,8 +125,9 @@ segment_csr(at::Tensor src, at::Tensor indptr, at::optional<at::Tensor> out_opt,
     auto src_data = src.DATA_PTR<scalar_t>();
     auto out_data = out.DATA_PTR<scalar_t>();
 
-    scalar_t vals[K];
-    int64_t row_start, row_end, args[K];
+    std::vector<scalar_t> vals(K);
+    int64_t row_start, row_end;
+    std::vector<int64_t> args(K);
     AT_DISPATCH_REDUCTION_TYPES(reduce, [&] {
       for (int n = 0; n < N; n++) {
         int offset = IndexPtrToOffset<int64_t>::get(n, indptr_info);
@@ -195,8 +198,9 @@ segment_coo(at::Tensor src, at::Tensor index, at::Tensor out,
     auto src_data = src.DATA_PTR<scalar_t>();
     auto out_data = out.DATA_PTR<scalar_t>();
 
-    scalar_t vals[K];
-    int64_t idx, next_idx, row_start, args[K];
+    std::vector<scalar_t> vals(K);
+    int64_t idx, next_idx, row_start;
+    std::vector<int64_t> args(K);
     AT_DISPATCH_REDUCTION_TYPES(reduce, [&] {
       for (int e_1 = 0; e_1 < E_1; e_1++) {
         int offset = IndexToOffset<int64_t>::get(e_1 * E_2, index_info);


### PR DESCRIPTION
Fixes "error C2131: expression did not evaluate to a constant" during compilation.

This error is caused by the lambda function in gather.cpp both in lines 44 to 66 and 105 to 137 using a variable length array "vals[K]". Regular C-Style Arrays need to be initialized with a constant expression that can be evaluated during compilation. Replacing this with a std::vector<scalar_t> initialized with K zeros solves the problem.