### PR TITLE
 Check if CUDA is available before checking CUDA version

### DIFF
--- a/torch_scatter/__init__.py
+++ b/torch_scatter/__init__.py
@@ -39,7 +39,7 @@ except AttributeError as e:
     torch.ops.torch_scatter.segment_max_coo = segment_coo_arg_placeholder
     torch.ops.torch_scatter.gather_coo = gather_coo_placeholder
 
-if torch.version.cuda is not None:  # pragma: no cover
+if torch.version.cuda is not None and torch.cuda.is_available():  # pragma: no cover
     cuda_version = torch.ops.torch_scatter.cuda_version()
 
     if cuda_version == -1:


### PR DESCRIPTION
`torch.version.cuda` can still exists when it was installed CPU-only.

`torch_scatter` would need the same fix for it to work though. 

For now, the workaround is 
```python
import torch
if not torch.cuda.is_available():
    torch.version.cuda = None
```

Same as [this one](https://github.com/rusty1s/pytorch_sparse/pull/72)