### PR TITLE
Add optional parameter to `scatter_[log_]softmax` to indicate the number of segments

### DIFF
--- a/torch_scatter/composite/softmax.py
+++ b/torch_scatter/composite/softmax.py
@@ -7,39 +7,45 @@ from torch_scatter.utils import broadcast
 
 
 def scatter_softmax(src: torch.Tensor, index: torch.Tensor,
-                    dim: int = -1, dim_size: Optional[int] = None) -> torch.Tensor:
+                    dim: int = -1,
+                    dim_size: Optional[int] = None) -> torch.Tensor:
     if not torch.is_floating_point(src):
         raise ValueError('`scatter_softmax` can only be computed over tensors '
                          'with floating point data types.')
 
     index = broadcast(index, src, dim)
 
-    max_value_per_index = scatter_max(src, index, dim=dim, dim_size=dim_size)[0]
+    max_value_per_index = scatter_max(
+        src, index, dim=dim, dim_size=dim_size)[0]
     max_per_src_element = max_value_per_index.gather(dim, index)
 
     recentered_scores = src - max_per_src_element
     recentered_scores_exp = recentered_scores.exp_()
 
-    sum_per_index = scatter_sum(recentered_scores_exp, index, dim, dim_size=dim_size)
+    sum_per_index = scatter_sum(
+        recentered_scores_exp, index, dim, dim_size=dim_size)
     normalizing_constants = sum_per_index.gather(dim, index)
 
     return recentered_scores_exp.div(normalizing_constants)
 
 
 def scatter_log_softmax(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
-                        eps: float = 1e-12, dim_size: Optional[int] = None) -> torch.Tensor:
+                        eps: float = 1e-12,
+                        dim_size: Optional[int] = None) -> torch.Tensor:
     if not torch.is_floating_point(src):
         raise ValueError('`scatter_log_softmax` can only be computed over '
                          'tensors with floating point data types.')
 
     index = broadcast(index, src, dim)
 
-    max_value_per_index = scatter_max(src, index, dim=dim, dim_size=dim_size)[0]
+    max_value_per_index = scatter_max(
+        src, index, dim=dim, dim_size=dim_size)[0]
     max_per_src_element = max_value_per_index.gather(dim, index)
 
     recentered_scores = src - max_per_src_element
 
-    sum_per_index = scatter_sum(recentered_scores.exp(), index, dim, dim_size=dim_size)
+    sum_per_index = scatter_sum(
+        recentered_scores.exp(), index, dim, dim_size=dim_size)
     normalizing_constants = sum_per_index.add_(eps).log_().gather(dim, index)
 
     return recentered_scores.sub_(normalizing_constants)


### PR DESCRIPTION
This adds an optional parameter to the `scatter_softmax` and `scatter_log_softmax` to indicate the number of segments, when this information is available and is backwards compatible.

The reason for this change is that `scatter_max` without `dim_size` causes a [CUDA stream synchronization and GPU->CPU transfer](https://github.com/rusty1s/pytorch_scatter/blob/26844e1145daccff879bba1429d477a6fde7920f/csrc/cuda/scatter_cuda.cu#L87) in order to retrieve the number of segments. When the number of segments is known.

❓ Should the parameter be called `dim_size` (consistent with the other ops) or something else (e.g. `num_segments`)?