### PR TITLE
Change other to other.size() for compatibility

### DIFF
--- a/torch_scatter/utils.py
+++ b/torch_scatter/utils.py
@@ -9,5 +9,5 @@ def broadcast(src: torch.Tensor, other: torch.Tensor, dim: int):
             src = src.unsqueeze(0)
     for _ in range(src.dim(), other.dim()):
         src = src.unsqueeze(-1)
-    src = src.expand_as(other)
+    src = src.expand_as(other.size())
     return src

--- a/torch_scatter/utils.py
+++ b/torch_scatter/utils.py
@@ -9,5 +9,5 @@ def broadcast(src: torch.Tensor, other: torch.Tensor, dim: int):
             src = src.unsqueeze(0)
     for _ in range(src.dim(), other.dim()):
         src = src.unsqueeze(-1)
-    src = src.expand_as(other.size())
+    src = src.expand(other.size())
     return src


### PR DESCRIPTION
When I was trying to change the code in one of the offical [examples](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/graph_sage_unsup.py) in [pytorch-geometric](https://github.com/pyg-team/pytorch_geometric) to use [torch-quiver](https://github.com/quiver-team/torch-quiver), I meet some problems.  When executing the penultimate line of the following code `src = src.expand_as(other)`
```python
def broadcast(src: torch.Tensor, other: torch.Tensor, dim: int):
    if dim < 0:
        dim = other.dim() + dim
    if src.dim() == 1:
        for _ in range(0, dim):
            src = src.unsqueeze(0)
    for _ in range(src.dim(), other.dim()):
        src = src.unsqueeze(-1)
    src = src.expand_as(other)
    return src
```
 I got an error 
```shell
TypeError: expand_as(): argument 'other' (position 1) must be Tensor, not Feature
```
But after alterating the `other` with `other.size()`, the quiver code becomes compatible with the torch-scatter code. According to the [pytorch official doc](https://pytorch.org/docs/stable/generated/torch.Tensor.expand_as.html), these two methods of passing parameters are equivalent to each other.  So for compatibility reasons and also for the [torch-quiver](https://github.com/quiver-team/torch-quiver)'s needs, could your approve this alteration?