### PR TITLE
Add build requirements in `pyproject.toml` to make installations easier

### DIFF
--- a/.github/workflows/testing-automated.yml
+++ b/.github/workflows/testing-automated.yml
@@ -18,19 +18,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install main package
+      - name: Install dependencies
         run: |
-          pip install .[test]
+          pip install tox
 
       - name: Run test-suite
         run: |
-          pytest
-
-      - name: Generate coverage report
-        if: success()
-        run: |
-          pip install coverage
-          coverage xml
+          tox -e py
 
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/testing-automated.yml
+++ b/.github/workflows/testing-automated.yml
@@ -1,0 +1,39 @@
+name: Testing with Automated Installation
+
+on: [push, pull_request]
+
+jobs:
+  preinstalled:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.6"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install main package
+        run: |
+          pip install .[test]
+
+      - name: Run test-suite
+        run: |
+          pytest
+
+      - name: Generate coverage report
+        if: success()
+        run: |
+          pip install coverage
+          coverage xml
+
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v1
+        if: success()
+        with:
+          file: coverage.xml

--- a/.github/workflows/testing-automated.yml
+++ b/.github/workflows/testing-automated.yml
@@ -1,15 +1,15 @@
-name: Testing with Automated Installation
+name: Testing w/ Automated Installation
 
 on: [push, pull_request]
 
 jobs:
-  preinstalled:
+  pytest:
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6"]
+        python-version: ["3.6", "39"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testing-automated.yml
+++ b/.github/workflows/testing-automated.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "39"]
+        python-version: ["3.6", "3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6]
+        python-version: ["3.6", "3.9"]
         torch-version: [1.9.0, 1.10.0]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install PyTorch ${{ matrix.torch-version }}
-        run: |
-          pip install torch==${{ matrix.torch-version}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-
       - name: Install main package
         run: |
           pip install -e .[test]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install PyTorch ${{ matrix.torch-version }}
+        run: |
+          pip install torch==${{ matrix.torch-version}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+
       - name: Install main package
         run: |
           pip install -e .[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+# See https://setuptools.readthedocs.io/en/latest/build_meta.html
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def get_extensions():
     return extensions
 
 
-install_requires = []
+install_requires = ['torch']
 setup_requires = []
 tests_require = ['pytest', 'pytest-runner', 'pytest-cov']
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+# To use a PEP 517 build-backend you are required to configure tox to use an isolated_build:
+# https://tox.readthedocs.io/en/latest/example/package.html
+isolated_build = True
+
+# These environments are run in order if you just use `tox`:
+envlist =
+    py
+
+[testenv]
+commands =
+    coverage run -p -m pytest --durations=20 {posargs:tests}
+    coverage combine
+    coverage xml
+extras =
+    test

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,9 @@ envlist =
     py
 
 [testenv]
+usedevelop = true
 commands =
-    coverage run -p -m pytest --durations=20 {posargs:tests}
+    pytest
     coverage combine
     coverage xml
 extras =


### PR DESCRIPTION
Closes #265

This pull request does the following:

1. Adds `torch` as a build requirement using `pyproject.toml` as described in https://setuptools.readthedocs.io/en/latest/build_meta.html. The use of `setup.py` is getting towards the end of life, and using a combination of declarative setup metadata in `setup.cfg` and `pyproject.toml` is the preferred way forwards. This means that if `torch` isn't already installed before doing `pip install torch-scatter`, it gets installed.
2. Adds `torch` as a install requirement (i.e., a dependency). This might be a bit redundant of 1, but some tools like `tox` create a separate env for the build requirements, so this needs to be duplicated.
3. Adds an alternative testing scenario in which PyTorch is _not_ installed before trying to `pip install torch-scatter`. This demonstrates that with the first two changes, it's now possible to make an automated, single step installation of `torch-scatter`.

## Why is this important

Creating easily installable packages that depend on `torch-scatter` (that don't include the need for manual installation of torch + cuda) is not currently possible because pip's dependency resolver isn't aware of the fact that `torch-scatter` needs torch installed before even trying to build it.