### PR TITLE
Improve GitHub Action for testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.6", "3.9"]
         torch-version: [1.9.0, 1.10.0]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run test-suite
         run: |
-          pytest
+          coverage run -p -m pytest
 
       - name: Generate coverage report
         if: success()

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Generate coverage report
         if: success()
         run: |
-          pip install coverage
           coverage xml
 
       - name: Upload coverage report to codecov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6]
+        python-version: ["3.6", "3.9"]
         torch-version: [1.9.0, 1.10.0]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run test-suite
         run: |
-          coverage run -p -m pytest
+          pytest --capture=no --cov
 
       - name: Generate coverage report
         if: success()

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install main package
         run: |
-          pip install -e .[test]
+          pip install .[test]
 
       - name: Run test-suite
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,9 @@ jobs:
 
       - name: Install main package
         run: |
-          pip install .[test]
+          # the -e/--editable flag is required otherwise the following error is raised:
+          # ImportError: Could not find module '_version_cpu' in /home/runner/work/pytorch_scatter/pytorch_scatter/torch_scatter
+          pip install -e .[test]
 
       - name: Run test-suite
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.6", "3.9"]
         torch-version: [1.9.0, 1.10.0]
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run test-suite
         run: |
-          python setup.py test
+          pytest
 
       - name: Generate coverage report
         if: success()

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extensions():
 
 install_requires = []
 setup_requires = []
-tests_require = ['pytest', 'pytest-runner', 'pytest-cov']
+tests_require = ['pytest', 'pytest-runner', 'pytest-cov', 'coverage']
 
 setup(
     name='torch_scatter',

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def get_extensions():
 
 
 install_requires = ['torch']
-setup_requires = ['torch']
+setup_requires = []
 tests_require = ['pytest', 'pytest-cov', 'coverage']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_extensions():
 
 install_requires = []
 setup_requires = []
-tests_require = ['pytest', 'pytest-runner', 'pytest-cov', 'coverage']
+tests_require = ['pytest', 'pytest-cov', 'coverage']
 
 setup(
     name='torch_scatter',

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def get_extensions():
 
 
 install_requires = ['torch']
-setup_requires = []
+setup_requires = ['torch']
 tests_require = ['pytest', 'pytest-cov', 'coverage']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ def get_extensions():
     return extensions
 
 
-install_requires = []
+install_requires = ['torch']
 setup_requires = []
 tests_require = ['pytest', 'pytest-cov', 'coverage']
 


### PR DESCRIPTION
As I'm trying to figure out why #266 isn't working, I want to try adding a couple less controversial things to the existing testing workflow

- [x] Test on more modern versions of Python (3.6 has passed its end of life as of December 2021)
- [x] Test directly with `pytest` instead of `setup.py` (the Python Packge Authority has deprecated all usages of `setup.py` as a script
- [x] Add `torch` to `install_requires` in the `setup.py` to signify that this package requires `torch` after it's installed. You can always install a specific version of `torch` before trying to install `torch-scatter` and it will respect what's already available in the environment.

Things that didn't work:

1. Testing on Mac OS~ (this doesn't work without getting rid of the `+cpu`)
2. Removing the `-e` (editable mode) flag causes `ImportError: Could not find module '_version_cpu' in /home/runner/work/pytorch_scatter/pytorch_scatter/torch_scatter`
3. Adding `torch` to `setup_requires` in the `setup.py` is a bit of a Catch-22: you already have to be executing the `setup.py` to recognize that. Getting this right can probably be done with the declarative setup that I proposed in #266, but that one still needs a few things to be clarified (plus CI to pass)