### PR TITLE
[WIP] Parallelize CPU scatter implementation

### DIFF
--- a/csrc/cpu/scatter_cpu.cpp
+++ b/csrc/cpu/scatter_cpu.cpp
@@ -10,9 +10,9 @@
 #include <stdio.h>
 #include <mutex>
 
-const int N_MUTEXES = 256;
-const int B_GRAIN_SIZE = 512;
-const int E_GRAIN_SIZE = 512;
+const int N_MUTEXES = 128;
+const int B_GRAIN_SIZE = 32;
+const int E_GRAIN_SIZE = 16;
 std::array<std::mutex, N_MUTEXES> mutexes;
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>

--- a/csrc/cpu/scatter_cpu.cpp
+++ b/csrc/cpu/scatter_cpu.cpp
@@ -10,7 +10,9 @@
 #include <stdio.h>
 #include <mutex>
 
-const int N_MUTEXES = 20;
+const int N_MUTEXES = 256;
+const int B_GRAIN_SIZE = 512;
+const int E_GRAIN_SIZE = 512;
 std::array<std::mutex, N_MUTEXES> mutexes;
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
@@ -89,11 +91,11 @@ scatter_cpu(torch::Tensor src, torch::Tensor index, int64_t dim,
       */
 
       // batch dimension(s) [parallel]
-      at::parallel_for(0, B, 5, [&](int64_t begin, int64_t end) {
+      at::parallel_for(0, B, B_GRAIN_SIZE, [&](int64_t begin, int64_t end) {
         for (int b = begin; b < end; b++) {
 
           // scatter dimension [parallel]
-          at::parallel_for(0, E, 5, [&](int64_t begin_2, int64_t end_2) { 
+          at::parallel_for(0, E, E_GRAIN_SIZE, [&](int64_t begin_2, int64_t end_2) { 
             for(auto e = begin_2; e < end_2; e++) {
               
               // all other dimensions [serial]

--- a/test/test_broadcasting.py
+++ b/test/test_broadcasting.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from torch_scatter import scatter
 
-from .utils import reductions, devices
+from .utils import devices, reductions
 
 
 @pytest.mark.parametrize('reduce,device', product(reductions, devices))


### PR DESCRIPTION
There are three axes of parallelism in the current implementation: batch_dim-wise (easiest, does not require any locking), scatter_dim-wise (requires locking), and all other dim-wise (requires locking). This implementation attempts to balance the overhead from generating too many threads with the benefits gained from parallelizing across two of these three axes.

Still a work in progress pending benchmarking tests.