### PR TITLE
Add capability to optionally include python during compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(TORCHSCATTER_VERSION 2.0.9)
 
 option(WITH_CUDA "Enable CUDA support" OFF)
+option(WITH_PYTHON "Link to Python when building" ON)
 
 if(WITH_CUDA)
   enable_language(CUDA)
@@ -12,7 +13,10 @@ if(WITH_CUDA)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 endif()
 
-find_package(Python3 COMPONENTS Development)
+if (WITH_PYTHON)
+  add_definitions(-DWITH_PYTHON)
+  find_package(Python3 COMPONENTS Development)
+endif()
 find_package(Torch REQUIRED)
 
 file(GLOB HEADERS csrc/*.h)
@@ -22,7 +26,10 @@ if(WITH_CUDA)
 endif()
 
 add_library(${PROJECT_NAME} SHARED ${OPERATOR_SOURCES})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} Python3::Python)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
+if (WITH_PYTHON)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Python3::Python)
+endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME TorchScatter)
 
 target_include_directories(${PROJECT_NAME} INTERFACE

--- a/csrc/cpu/index_info.h
+++ b/csrc/cpu/index_info.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 #define MAX_TENSORINFO_DIMS 25
 

--- a/csrc/cpu/scatter_cpu.h
+++ b/csrc/cpu/scatter_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 scatter_cpu(torch::Tensor src, torch::Tensor index, int64_t dim,

--- a/csrc/cpu/segment_coo_cpu.h
+++ b/csrc/cpu/segment_coo_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 segment_coo_cpu(torch::Tensor src, torch::Tensor index,

--- a/csrc/cpu/segment_csr_cpu.h
+++ b/csrc/cpu/segment_csr_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 segment_csr_cpu(torch::Tensor src, torch::Tensor indptr,

--- a/csrc/cpu/utils.h
+++ b/csrc/cpu/utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 #define CHECK_CPU(x) AT_ASSERTM(x.device().is_cpu(), #x " must be CPU tensor")
 #define CHECK_INPUT(x) AT_ASSERTM(x, "Input mismatch")

--- a/csrc/cuda/scatter_cuda.h
+++ b/csrc/cuda/scatter_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 scatter_cuda(torch::Tensor src, torch::Tensor index, int64_t dim,

--- a/csrc/cuda/segment_coo_cuda.h
+++ b/csrc/cuda/segment_coo_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 segment_coo_cuda(torch::Tensor src, torch::Tensor index,

--- a/csrc/cuda/segment_csr_cuda.h
+++ b/csrc/cuda/segment_csr_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 segment_csr_cuda(torch::Tensor src, torch::Tensor indptr,

--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include "../extensions.h"
 
 #define CHECK_CUDA(x)                                                          \
   AT_ASSERTM(x.device().is_cuda(), #x " must be CUDA tensor")

--- a/csrc/extensions.h
+++ b/csrc/extensions.h
@@ -1,0 +1,2 @@
+#include "macros.h"
+#include <torch/torch.h>

--- a/csrc/scatter.cpp
+++ b/csrc/scatter.cpp
@@ -1,4 +1,7 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
+
 #include <torch/script.h>
 
 #include "cpu/scatter_cpu.h"
@@ -10,10 +13,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__scatter_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__scatter_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/scatter.h
+++ b/csrc/scatter.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
-
-#include "macros.h"
+#include "extensions.h"
 
 namespace scatter {
 SCATTER_API int64_t cuda_version() noexcept;

--- a/csrc/segment_coo.cpp
+++ b/csrc/segment_coo.cpp
@@ -1,4 +1,7 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
+
 #include <torch/script.h>
 
 #include "cpu/segment_coo_cpu.h"
@@ -10,10 +13,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__segment_coo_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__segment_coo_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/segment_csr.cpp
+++ b/csrc/segment_csr.cpp
@@ -1,4 +1,7 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
+
 #include <torch/script.h>
 
 #include "cpu/segment_csr_cpu.h"
@@ -10,10 +13,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__segment_csr_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__segment_csr_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/version.cpp
+++ b/csrc/version.cpp
@@ -1,4 +1,7 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
+
 #include <torch/script.h>
 #include "scatter.h"
 #include "macros.h"
@@ -8,10 +11,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__version_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__version_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_extensions():
     main_files = glob.glob(osp.join(extensions_dir, '*.cpp'))
 
     for main, suffix in product(main_files, suffices):
-        define_macros = []
+        define_macros = [('WITH_PYTHON', None)]
 
         if sys.platform == 'win32':
             define_macros += [('torchscatter_EXPORTS', None)]


### PR DESCRIPTION
Hi all,

Are you interested in adding the option to conditionally include Python? So that the C++ library can be used without linking a Python library - similar to [this PR for `torch_sparse`](https://github.com/rusty1s/pytorch_sparse/pull/196). Style of changes copied from that PR also.