### PR TITLE
Use `static constexpr` for VS compilation

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -59,6 +59,14 @@ jobs:
           python -c "import torch; print('PyTorch:', torch.__version__)"
           python -c "import torch; print('CUDA:', torch.version.cuda)"
 
+      - name: Patch PyTorch static constexpr on Windows
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          Torch_DIR=`python -c 'import os; import torch;print(os.path.dirname(torch.__file__))'`
+          sed -i '32,38c\
+TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+        shell: bash
+
       - name: Set version
         if: ${{ runner.os != 'macOS' }}
         run: |

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Patch PyTorch static constexpr on Windows
         if: ${{ runner.os == 'Windows' }}
         run: |
-          Torch_DIR=`python -c 'import os; import torch;print(os.path.dirname(torch.__file__))'`
+          Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
           sed -i '32,38c\
-TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+            TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash
 
       - name: Set version

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -63,8 +63,8 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         run: |
           Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
-          sed -i '32,38c\
-            TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+          sed -i '31,38c\
+          TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash
 
       - name: Set version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Install PyTorch ${{ matrix.torch-version }}
         run: |
           pip install torch==${{ matrix.torch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
-
+          sed -i '32,38c\
+TORCH_API void lazy_init_num_threads();' "$(python -c "import os, torch; print(os.path.join(os.path.dirname(torch.__file__), 'include/ATen/Parallel.h'))")"
+          
       - name: Install main package
         run: |
           pip install -e .[test]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Patch PyTorch static constexpr on Windows
         if: ${{ runner.os == 'Windows' }}
         run: |
-          Torch_DIR=`python -c 'import os; import torch;print(os.path.dirname(torch.__file__))'`
+          Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
           sed -i '32,38c\
-TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+            TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash
 
       - name: Install main package

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,11 +33,11 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         run: |
           Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
-          cat ${Torch_DIR}/include/ATen/Paralle.h
+          cat ${Torch_DIR}/include/ATen/Parallel.h
           echo "================"
           sed -i '32,38c\
             TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
-          cat ${Torch_DIR}/include/ATen/Paralle.h
+          cat ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash
 
       - name: Install main package

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
           Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
           cat ${Torch_DIR}/include/ATen/Parallel.h
           echo "================"
-          sed -i '32,38c\
+          sed -i '31,38c\
             TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
           cat ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
           cat ${Torch_DIR}/include/ATen/Parallel.h
           echo "================"
           sed -i '31,38c\
-            TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+          TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
           cat ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,8 +33,11 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         run: |
           Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
+          cat ${Torch_DIR}/include/ATen/Paralle.h
+          echo "================"
           sed -i '32,38c\
             TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+          cat ${Torch_DIR}/include/ATen/Paralle.h
         shell: bash
 
       - name: Install main package

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,9 +28,15 @@ jobs:
       - name: Install PyTorch ${{ matrix.torch-version }}
         run: |
           pip install torch==${{ matrix.torch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
+
+      - name: Patch PyTorch static constexpr on Windows
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          Torch_DIR=`python -c 'import os; import torch;print(os.path.dirname(torch.__file__))'`
           sed -i '32,38c\
-TORCH_API void lazy_init_num_threads();' "$(python -c "import os, torch; print(os.path.join(os.path.dirname(torch.__file__), 'include/ATen/Parallel.h'))")"
-          
+TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
+        shell: bash
+
       - name: Install main package
         run: |
           pip install -e .[test]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,11 +33,8 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         run: |
           Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
-          cat ${Torch_DIR}/include/ATen/Parallel.h
-          echo "================"
           sed -i '31,38c\
           TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
-          cat ${Torch_DIR}/include/ATen/Parallel.h
         shell: bash
 
       - name: Install main package

--- a/csrc/cuda/reducer.cuh
+++ b/csrc/cuda/reducer.cuh
@@ -16,27 +16,27 @@ const std::map<std::string, ReductionType> reduce2REDUCE = {
   [&] {                                                                        \
     switch (reduce2REDUCE.at(reduce)) {                                        \
     case SUM: {                                                                \
-      const ReductionType REDUCE = SUM;                                        \
+      static constexpr ReductionType REDUCE = SUM;                                        \
       return __VA_ARGS__();                                                    \
     }                                                                          \
     case MEAN: {                                                               \
-      const ReductionType REDUCE = MEAN;                                       \
+      static constexpr ReductionType REDUCE = MEAN;                                       \
       return __VA_ARGS__();                                                    \
     }                                                                          \
     case MUL: {                                                                \
-      const ReductionType REDUCE = MUL;                                        \
+      static constexpr ReductionType REDUCE = MUL;                                        \
       return __VA_ARGS__();                                                    \
     }                                                                          \
     case DIV: {                                                                \
-      const ReductionType REDUCE = DIV;                                        \
+      static constexpr ReductionType REDUCE = DIV;                                        \
       return __VA_ARGS__();                                                    \
     }                                                                          \
     case MIN: {                                                                \
-      const ReductionType REDUCE = MIN;                                        \
+      static constexpr ReductionType REDUCE = MIN;                                        \
       return __VA_ARGS__();                                                    \
     }                                                                          \
     case MAX: {                                                                \
-      const ReductionType REDUCE = MAX;                                        \
+      static constexpr ReductionType REDUCE = MAX;                                        \
       return __VA_ARGS__();                                                    \
     }                                                                          \
     }                                                                          \


### PR DESCRIPTION
static constexpr should be used in macro in cuda/reducer.cuh, otherwise VS compilation will fail with error C2975: 'REDUCE': invalid template argument for 'Reducer', expected compile-time constant expression