### PR TITLE
Fix compilation errors occurring when building with PyTorch-nightly

### DIFF
--- a/csrc/version.cpp
+++ b/csrc/version.cpp
@@ -39,4 +39,4 @@ SCATTER_API int64_t cuda_version() noexcept {
 } // namespace scatter
 
 static auto registry = torch::RegisterOperators().op(
-    "torch_scatter::cuda_version", &scatter::cuda_version);
+    "torch_scatter::cuda_version", [] { return scatter::cuda_version(); });


### PR DESCRIPTION
Fix compilation errors occurring when building with PyTorch-nightly.
Wrapping the `cuda_version` function with a lambda helps to deduce template type.

Related PR: [pytorch_sparse::PR-305](https://github.com/rusty1s/pytorch_sparse/pull/305)