### PR TITLE
Fix cmake abosule paths in build interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME TorchScatter)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
-  $<BUILD_INTERFACE:${HEADERS}>
+  "$<BUILD_INTERFACE:${HEADERS}>"
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
GLOB creates absolute paths requiring the BUILD_INTERFACE generator to be placed inside quotes.

Currently, here is what the autogenerated `TorchScatterTargets.cmake` looks like:

```cmake
set_target_properties(TorchScatter::TorchScatter PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "/home/user/opt/pytorch_scatter/"
)
```

This causes an error when the `TorchScatter::TorchScatter` is added to other projects because of the absolute path.

Adding quotes to the generator in CMakeLists.txt fixes this issue.
```cmake
target_include_directories(${PROJECT_NAME} INTERFACE
  "$<BUILD_INTERFACE:${HEADERS}>"
  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
```
