### PR TITLE
logsumexp handling of edge-cases

### DIFF
--- a/torch_scatter/composite/logsumexp.py
+++ b/torch_scatter/composite/logsumexp.py
@@ -8,8 +8,7 @@ from torch_scatter.utils import broadcast
 
 def scatter_logsumexp(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
                       out: Optional[torch.Tensor] = None,
-                      dim_size: Optional[int] = None,
-                      eps: float = 1e-12) -> torch.Tensor:
+                      dim_size: Optional[int] = None) -> torch.Tensor:
     if not torch.is_floating_point(src):
         raise ValueError('`scatter_logsumexp` can only be computed over '
                          'tensors with floating point data types.')
@@ -24,18 +23,19 @@ def scatter_logsumexp(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
 
     size = list(src.size())
     size[dim] = dim_size
+
     max_value_per_index = torch.full(size, float('-inf'), dtype=src.dtype,
                                      device=src.device)
-    scatter_max(src, index, dim, max_value_per_index, dim_size=dim_size)[0]
+    scatter_max(src, index, dim, max_value_per_index, dim_size=dim_size)
+    max_value_per_index.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
     max_per_src_element = max_value_per_index.gather(dim, index)
-    recentered_score = src - max_per_src_element
-    recentered_score.masked_fill_(torch.isnan(recentered_score), float('-inf'))
-
+    
+    src_recentered = src - max_per_src_element
     if out is not None:
         out = out.sub_(max_value_per_index).exp_()
 
-    sum_per_index = scatter_sum(recentered_score.exp_(), index, dim, out,
+    sum_per_index = scatter_sum(src_recentered.exp_(), index, dim, out,
                                 dim_size)
 
-    out = sum_per_index.add_(eps).log_().add_(max_value_per_index)
-    return out.nan_to_num_(neginf=0.0)
+    return sum_per_index.log_().add_(max_value_per_index)
+    

--- a/torch_scatter/testing.py
+++ b/torch_scatter/testing.py
@@ -8,6 +8,7 @@ dtypes = [
     torch.half, torch.bfloat16, torch.float, torch.double, torch.int,
     torch.long
 ]
+float_dtypes = list(filter(lambda x: x.is_floating_point, dtypes))
 grad_dtypes = [torch.float, torch.double]
 
 devices = [torch.device('cpu')]
@@ -17,3 +18,7 @@ if torch.cuda.is_available():
 
 def tensor(x: Any, dtype: torch.dtype, device: torch.device):
     return None if x is None else torch.tensor(x, device=device).to(dtype)
+
+
+def assert_equal(actual: torch.Tensor, expected: torch.Tensor, equal_nan=False):
+    torch.testing.assert_close(actual, expected, equal_nan=equal_nan, rtol=0, atol=0)


### PR DESCRIPTION
Hi! First of all thanks for this library, which has been useful in a few projects.

I've run into some inconsistencies between the torch_scatter.logsumexp and torch.logsumexp:

1) logsumexp of no elements should default to `-inf`, not `0`.
    This is equivalent to having sum(..., start=0) in non-log space.  
    `torch.logsumexp(torch.tensor([]), dim=0)` returns `-inf`.
2) it should not hide nans:
    `torch.logsumexp(torch.tensor([torch.nan]), dim=0)` returns `nan`.
3) no `eps` should be added. `torch.logsumexp` also doesn't have this.

In the first commit, I've added test cases for empty lists, -inf, inf, very large positive and negative numbers - and added a cartesian product test across the inputs and the various floating point data types.

In the second commit, I've changed the implementation to comply with the new tests.

### Dependency Management

On another note, I ended up spending a few hours setting up the torch/cuda dependencies correctly to build from source.
I ended up using the following commands to install deps, build from source and run the tests:

```bash
cd pytorch_scatter
conda create -n torchscatter python=3.10 pytorch::pytorch pytorch::pytorch-cuda=11.8 nvidia/label/cuda-11.8.0::cuda
conda activate torchscatter
pip install -e ".[test]"
pytest
```

Maybe having this or something similar in the docs (if it's not already there and I missed it) could make it easier for others to contribute. 