### PR TITLE
update the standard from 14 to 17 to avoid compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(torchscatter)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED)
 set(TORCHSCATTER_VERSION 2.1.2)
 
 option(WITH_CUDA "Enable CUDA support" OFF)


### PR DESCRIPTION
I am trying to implement the Graph network built based on `torch_geometric` to my cpp code by `libtorch`. 

Thus the `torchscatter` lib file is needed by the `GCNConv` jit.

While using the old version to compile the c++ torch extension lib, I met following error.

```
miniconda3/lib/python3.11/site-packages/torch/include/c10/util/MaybeOwned.h:142:54: error: expected '(' for function-style cast or type construction
  142 |       std::is_nothrow_move_assignable_v<borrow_type> &&
```

After changing the `CMAKE_CXX_STANDARD` from **14** to **17**, the error solved.