### PR TITLE
c10::optional -> std::optional

### DIFF
--- a/csrc/cpu/scatter_cpu.cpp
+++ b/csrc/cpu/scatter_cpu.cpp
@@ -4,10 +4,10 @@
 #include "reducer.h"
 #include "utils.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 scatter_cpu(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size, std::string reduce) {
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size, std::string reduce) {
   CHECK_CPU(src);
   CHECK_CPU(index);
   if (optional_out.has_value())
@@ -36,7 +36,7 @@ scatter_cpu(torch::Tensor src, torch::Tensor index, int64_t dim,
     out = torch::empty(sizes, src.options());
   }
 
-  torch::optional<torch::Tensor> arg_out = torch::nullopt;
+  std::optional<torch::Tensor> arg_out = std::nullopt;
   int64_t *arg_out_data = nullptr;
   if (reduce2REDUCE.at(reduce) == MIN || reduce2REDUCE.at(reduce) == MAX) {
     arg_out = torch::full_like(out, src.size(dim), index.options());

--- a/csrc/cpu/scatter_cpu.h
+++ b/csrc/cpu/scatter_cpu.h
@@ -2,7 +2,7 @@
 
 #include "../extensions.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 scatter_cpu(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size, std::string reduce);
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size, std::string reduce);

--- a/csrc/cpu/segment_coo_cpu.cpp
+++ b/csrc/cpu/segment_coo_cpu.cpp
@@ -5,10 +5,10 @@
 #include "utils.h"
 #include <ATen/OpMathType.h>
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_coo_cpu(torch::Tensor src, torch::Tensor index,
-                torch::optional<torch::Tensor> optional_out,
-                torch::optional<int64_t> dim_size, std::string reduce) {
+                std::optional<torch::Tensor> optional_out,
+                std::optional<int64_t> dim_size, std::string reduce) {
   CHECK_CPU(src);
   CHECK_CPU(index);
   if (optional_out.has_value())
@@ -45,7 +45,7 @@ segment_coo_cpu(torch::Tensor src, torch::Tensor index,
     out = torch::empty(sizes, src.options());
   }
 
-  torch::optional<torch::Tensor> arg_out = torch::nullopt;
+  std::optional<torch::Tensor> arg_out = std::nullopt;
   int64_t *arg_out_data = nullptr;
   if (reduce2REDUCE.at(reduce) == MIN || reduce2REDUCE.at(reduce) == MAX) {
     arg_out = torch::full_like(out, src.size(dim), index.options());
@@ -141,7 +141,7 @@ segment_coo_cpu(torch::Tensor src, torch::Tensor index,
 }
 
 torch::Tensor gather_coo_cpu(torch::Tensor src, torch::Tensor index,
-                             torch::optional<torch::Tensor> optional_out) {
+                             std::optional<torch::Tensor> optional_out) {
   CHECK_CPU(src);
   CHECK_CPU(index);
   if (optional_out.has_value())

--- a/csrc/cpu/segment_coo_cpu.h
+++ b/csrc/cpu/segment_coo_cpu.h
@@ -2,10 +2,10 @@
 
 #include "../extensions.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_coo_cpu(torch::Tensor src, torch::Tensor index,
-                torch::optional<torch::Tensor> optional_out,
-                torch::optional<int64_t> dim_size, std::string reduce);
+                std::optional<torch::Tensor> optional_out,
+                std::optional<int64_t> dim_size, std::string reduce);
 
 torch::Tensor gather_coo_cpu(torch::Tensor src, torch::Tensor index,
-                             torch::optional<torch::Tensor> optional_out);
+                             std::optional<torch::Tensor> optional_out);

--- a/csrc/cpu/segment_csr_cpu.cpp
+++ b/csrc/cpu/segment_csr_cpu.cpp
@@ -5,9 +5,9 @@
 #include "utils.h"
 #include <ATen/OpMathType.h>
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_csr_cpu(torch::Tensor src, torch::Tensor indptr,
-                torch::optional<torch::Tensor> optional_out,
+                std::optional<torch::Tensor> optional_out,
                 std::string reduce) {
   CHECK_CPU(src);
   CHECK_CPU(indptr);
@@ -38,7 +38,7 @@ segment_csr_cpu(torch::Tensor src, torch::Tensor indptr,
     out = torch::empty(sizes, src.options());
   }
 
-  torch::optional<torch::Tensor> arg_out = torch::nullopt;
+  std::optional<torch::Tensor> arg_out = std::nullopt;
   int64_t *arg_out_data = nullptr;
   if (reduce2REDUCE.at(reduce) == MIN || reduce2REDUCE.at(reduce) == MAX) {
     arg_out = torch::full(out.sizes(), src.size(dim), indptr.options());
@@ -92,7 +92,7 @@ segment_csr_cpu(torch::Tensor src, torch::Tensor indptr,
 }
 
 torch::Tensor gather_csr_cpu(torch::Tensor src, torch::Tensor indptr,
-                             torch::optional<torch::Tensor> optional_out) {
+                             std::optional<torch::Tensor> optional_out) {
   CHECK_CPU(src);
   CHECK_CPU(indptr);
   if (optional_out.has_value())

--- a/csrc/cpu/segment_csr_cpu.h
+++ b/csrc/cpu/segment_csr_cpu.h
@@ -2,10 +2,10 @@
 
 #include "../extensions.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_csr_cpu(torch::Tensor src, torch::Tensor indptr,
-                torch::optional<torch::Tensor> optional_out,
+                std::optional<torch::Tensor> optional_out,
                 std::string reduce);
 
 torch::Tensor gather_csr_cpu(torch::Tensor src, torch::Tensor indptr,
-                             torch::optional<torch::Tensor> optional_out);
+                             std::optional<torch::Tensor> optional_out);

--- a/csrc/cuda/scatter_cuda.cu
+++ b/csrc/cuda/scatter_cuda.cu
@@ -55,10 +55,10 @@ scatter_arg_kernel(const scalar_t *src_data,
   }
 }
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 scatter_cuda(torch::Tensor src, torch::Tensor index, int64_t dim,
-             torch::optional<torch::Tensor> optional_out,
-             torch::optional<int64_t> dim_size, std::string reduce) {
+             std::optional<torch::Tensor> optional_out,
+             std::optional<int64_t> dim_size, std::string reduce) {
   CHECK_CUDA(src);
   CHECK_CUDA(index);
   if (optional_out.has_value())
@@ -89,7 +89,7 @@ scatter_cuda(torch::Tensor src, torch::Tensor index, int64_t dim,
     out = torch::empty(sizes, src.options());
   }
 
-  torch::optional<torch::Tensor> arg_out = torch::nullopt;
+  std::optional<torch::Tensor> arg_out = std::nullopt;
   int64_t *arg_out_data = nullptr;
   if (reduce2REDUCE.at(reduce) == MIN || reduce2REDUCE.at(reduce) == MAX) {
     arg_out = torch::full_like(out, src.size(dim), index.options());

--- a/csrc/cuda/scatter_cuda.h
+++ b/csrc/cuda/scatter_cuda.h
@@ -2,7 +2,7 @@
 
 #include "../extensions.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 scatter_cuda(torch::Tensor src, torch::Tensor index, int64_t dim,
-             torch::optional<torch::Tensor> optional_out,
-             torch::optional<int64_t> dim_size, std::string reduce);
+             std::optional<torch::Tensor> optional_out,
+             std::optional<int64_t> dim_size, std::string reduce);

--- a/csrc/cuda/segment_coo_cuda.cu
+++ b/csrc/cuda/segment_coo_cuda.cu
@@ -149,10 +149,10 @@ __global__ void segment_coo_arg_broadcast_kernel(
   }
 }
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_coo_cuda(torch::Tensor src, torch::Tensor index,
-                 torch::optional<torch::Tensor> optional_out,
-                 torch::optional<int64_t> dim_size, std::string reduce) {
+                 std::optional<torch::Tensor> optional_out,
+                 std::optional<int64_t> dim_size, std::string reduce) {
   CHECK_CUDA(src);
   CHECK_CUDA(index);
   if (optional_out.has_value())
@@ -191,7 +191,7 @@ segment_coo_cuda(torch::Tensor src, torch::Tensor index,
     out = torch::zeros(sizes, src.options());
   }
 
-  torch::optional<torch::Tensor> arg_out = torch::nullopt;
+  std::optional<torch::Tensor> arg_out = std::nullopt;
   int64_t *arg_out_data = nullptr;
   if (reduce2REDUCE.at(reduce) == MIN || reduce2REDUCE.at(reduce) == MAX) {
     arg_out = torch::full_like(out, src.size(dim), index.options());
@@ -325,7 +325,7 @@ __global__ void gather_coo_broadcast_kernel(
 }
 
 torch::Tensor gather_coo_cuda(torch::Tensor src, torch::Tensor index,
-                              torch::optional<torch::Tensor> optional_out) {
+                              std::optional<torch::Tensor> optional_out) {
   CHECK_CUDA(src);
   CHECK_CUDA(index);
   if (optional_out.has_value())

--- a/csrc/cuda/segment_coo_cuda.h
+++ b/csrc/cuda/segment_coo_cuda.h
@@ -2,10 +2,10 @@
 
 #include "../extensions.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_coo_cuda(torch::Tensor src, torch::Tensor index,
-                 torch::optional<torch::Tensor> optional_out,
-                 torch::optional<int64_t> dim_size, std::string reduce);
+                 std::optional<torch::Tensor> optional_out,
+                 std::optional<int64_t> dim_size, std::string reduce);
 
 torch::Tensor gather_coo_cuda(torch::Tensor src, torch::Tensor index,
-                              torch::optional<torch::Tensor> optional_out);
+                              std::optional<torch::Tensor> optional_out);

--- a/csrc/cuda/segment_csr_cuda.cu
+++ b/csrc/cuda/segment_csr_cuda.cu
@@ -94,9 +94,9 @@ __global__ void segment_csr_broadcast_kernel(
   }
 }
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_csr_cuda(torch::Tensor src, torch::Tensor indptr,
-                 torch::optional<torch::Tensor> optional_out,
+                 std::optional<torch::Tensor> optional_out,
                  std::string reduce) {
   CHECK_CUDA(src);
   CHECK_CUDA(indptr);
@@ -128,7 +128,7 @@ segment_csr_cuda(torch::Tensor src, torch::Tensor indptr,
     out = torch::empty(sizes, src.options());
   }
 
-  torch::optional<torch::Tensor> arg_out = torch::nullopt;
+  std::optional<torch::Tensor> arg_out = std::nullopt;
   int64_t *arg_out_data = nullptr;
   if (reduce2REDUCE.at(reduce) == MIN || reduce2REDUCE.at(reduce) == MAX) {
     arg_out = torch::full(out.sizes(), src.size(dim), indptr.options());
@@ -217,7 +217,7 @@ __global__ void gather_csr_broadcast_kernel(
 }
 
 torch::Tensor gather_csr_cuda(torch::Tensor src, torch::Tensor indptr,
-                              torch::optional<torch::Tensor> optional_out) {
+                              std::optional<torch::Tensor> optional_out) {
   CHECK_CUDA(src);
   CHECK_CUDA(indptr);
   if (optional_out.has_value())

--- a/csrc/cuda/segment_csr_cuda.h
+++ b/csrc/cuda/segment_csr_cuda.h
@@ -2,10 +2,10 @@
 
 #include "../extensions.h"
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 segment_csr_cuda(torch::Tensor src, torch::Tensor indptr,
-                 torch::optional<torch::Tensor> optional_out,
+                 std::optional<torch::Tensor> optional_out,
                  std::string reduce);
 
 torch::Tensor gather_csr_cuda(torch::Tensor src, torch::Tensor indptr,
-                              torch::optional<torch::Tensor> optional_out);
+                              std::optional<torch::Tensor> optional_out);

--- a/csrc/scatter.cpp
+++ b/csrc/scatter.cpp
@@ -32,10 +32,10 @@ torch::Tensor broadcast(torch::Tensor src, torch::Tensor other, int64_t dim) {
   return src;
 }
 
-std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 scatter_fw(torch::Tensor src, torch::Tensor index, int64_t dim,
-           torch::optional<torch::Tensor> optional_out,
-           torch::optional<int64_t> dim_size, std::string reduce) {
+           std::optional<torch::Tensor> optional_out,
+           std::optional<int64_t> dim_size, std::string reduce) {
   if (src.device().is_cuda()) {
 #ifdef WITH_CUDA
     return scatter_cuda(src, index, dim, optional_out, dim_size, reduce);
@@ -55,8 +55,8 @@ class ScatterSum : public torch::autograd::Function<ScatterSum> {
 public:
   static variable_list forward(AutogradContext *ctx, Variable src,
                                Variable index, int64_t dim,
-                               torch::optional<Variable> optional_out,
-                               torch::optional<int64_t> dim_size) {
+                               std::optional<Variable> optional_out,
+                               std::optional<int64_t> dim_size) {
     dim = dim < 0 ? src.dim() + dim : dim;
     ctx->saved_data["dim"] = dim;
     ctx->saved_data["src_shape"] = src.sizes();
@@ -84,8 +84,8 @@ class ScatterMul : public torch::autograd::Function<ScatterMul> {
 public:
   static variable_list forward(AutogradContext *ctx, Variable src,
                                Variable index, int64_t dim,
-                               torch::optional<Variable> optional_out,
-                               torch::optional<int64_t> dim_size) {
+                               std::optional<Variable> optional_out,
+                               std::optional<int64_t> dim_size) {
     dim = dim < 0 ? src.dim() + dim : dim;
     ctx->saved_data["dim"] = dim;
     ctx->saved_data["src_shape"] = src.sizes();
@@ -116,8 +116,8 @@ class ScatterMean : public torch::autograd::Function<ScatterMean> {
 public:
   static variable_list forward(AutogradContext *ctx, Variable src,
                                Variable index, int64_t dim,
-                               torch::optional<Variable> optional_out,
-                               torch::optional<int64_t> dim_size) {
+                               std::optional<Variable> optional_out,
+                               std::optional<int64_t> dim_size) {
     dim = dim < 0 ? src.dim() + dim : dim;
     ctx->saved_data["dim"] = dim;
     ctx->saved_data["src_shape"] = src.sizes();
@@ -131,7 +131,7 @@ public:
     auto ones = torch::ones(old_index.sizes(), src.options());
     result = scatter_fw(ones, old_index,
                         old_index.dim() <= dim ? old_index.dim() - 1 : dim,
-                        torch::nullopt, out.size(dim), "sum");
+                        std::nullopt, out.size(dim), "sum");
     auto count = std::get<0>(result);
     count.masked_fill_(count < 1, 1);
     count = broadcast(count, out, dim);
@@ -164,8 +164,8 @@ class ScatterMin : public torch::autograd::Function<ScatterMin> {
 public:
   static variable_list forward(AutogradContext *ctx, Variable src,
                                Variable index, int64_t dim,
-                               torch::optional<Variable> optional_out,
-                               torch::optional<int64_t> dim_size) {
+                               std::optional<Variable> optional_out,
+                               std::optional<int64_t> dim_size) {
     dim = dim < 0 ? src.dim() + dim : dim;
     ctx->saved_data["dim"] = dim;
     ctx->saved_data["src_shape"] = src.sizes();
@@ -200,8 +200,8 @@ class ScatterMax : public torch::autograd::Function<ScatterMax> {
 public:
   static variable_list forward(AutogradContext *ctx, Variable src,
                                Variable index, int64_t dim,
-                               torch::optional<Variable> optional_out,
-                               torch::optional<int64_t> dim_size) {
+                               std::optional<Variable> optional_out,
+                               std::optional<int64_t> dim_size) {
     dim = dim < 0 ? src.dim() + dim : dim;
     ctx->saved_data["dim"] = dim;
     ctx->saved_data["src_shape"] = src.sizes();
@@ -234,37 +234,37 @@ public:
 
 SCATTER_API torch::Tensor
 scatter_sum(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size) {
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size) {
   return ScatterSum::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
 SCATTER_API torch::Tensor
 scatter_mul(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size) {
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size) {
   return ScatterMul::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
 SCATTER_API torch::Tensor
 scatter_mean(torch::Tensor src, torch::Tensor index, int64_t dim,
-             torch::optional<torch::Tensor> optional_out,
-             torch::optional<int64_t> dim_size) {
+             std::optional<torch::Tensor> optional_out,
+             std::optional<int64_t> dim_size) {
   return ScatterMean::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 scatter_min(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size) {
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size) {
   auto result = ScatterMin::apply(src, index, dim, optional_out, dim_size);
   return std::make_tuple(result[0], result[1]);
 }
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 scatter_max(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size) {
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size) {
   auto result = ScatterMax::apply(src, index, dim, optional_out, dim_size);
   return std::make_tuple(result[0], result[1]);
 }

--- a/csrc/scatter.h
+++ b/csrc/scatter.h
@@ -12,69 +12,69 @@ SCATTER_INLINE_VARIABLE int64_t _cuda_version = cuda_version();
 
 SCATTER_API torch::Tensor
 scatter_sum(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size);
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size);
 
 SCATTER_API torch::Tensor
 scatter_mul(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size);
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size);
 
 SCATTER_API torch::Tensor
 scatter_mean(torch::Tensor src, torch::Tensor index, int64_t dim,
-             torch::optional<torch::Tensor> optional_out,
-             torch::optional<int64_t> dim_size);
+             std::optional<torch::Tensor> optional_out,
+             std::optional<int64_t> dim_size);
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 scatter_min(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size);
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size);
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 scatter_max(torch::Tensor src, torch::Tensor index, int64_t dim,
-            torch::optional<torch::Tensor> optional_out,
-            torch::optional<int64_t> dim_size);
+            std::optional<torch::Tensor> optional_out,
+            std::optional<int64_t> dim_size);
 
 SCATTER_API torch::Tensor
 segment_sum_coo(torch::Tensor src, torch::Tensor index,
-                torch::optional<torch::Tensor> optional_out,
-                torch::optional<int64_t> dim_size);
+                std::optional<torch::Tensor> optional_out,
+                std::optional<int64_t> dim_size);
 
 SCATTER_API torch::Tensor
 segment_mean_coo(torch::Tensor src, torch::Tensor index,
-                 torch::optional<torch::Tensor> optional_out,
-                 torch::optional<int64_t> dim_size);
+                 std::optional<torch::Tensor> optional_out,
+                 std::optional<int64_t> dim_size);
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 segment_min_coo(torch::Tensor src, torch::Tensor index,
-                torch::optional<torch::Tensor> optional_out,
-                torch::optional<int64_t> dim_size);
+                std::optional<torch::Tensor> optional_out,
+                std::optional<int64_t> dim_size);
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 segment_max_coo(torch::Tensor src, torch::Tensor index,
-                torch::optional<torch::Tensor> optional_out,
-                torch::optional<int64_t> dim_size);
+                std::optional<torch::Tensor> optional_out,
+                std::optional<int64_t> dim_size);
 
 SCATTER_API torch::Tensor
 gather_coo(torch::Tensor src, torch::Tensor index,
-           torch::optional<torch::Tensor> optional_out);
+           std::optional<torch::Tensor> optional_out);
 
 SCATTER_API torch::Tensor
 segment_sum_csr(torch::Tensor src, torch::Tensor indptr,
-                torch::optional<torch::Tensor> optional_out);
+                std::optional<torch::Tensor> optional_out);
 
 SCATTER_API torch::Tensor
 segment_mean_csr(torch::Tensor src, torch::Tensor indptr,
-                 torch::optional<torch::Tensor> optional_out);
+                 std::optional<torch::Tensor> optional_out);
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 segment_min_csr(torch::Tensor src, torch::Tensor indptr,
-                torch::optional<torch::Tensor> optional_out);
+                std::optional<torch::Tensor> optional_out);
 
 SCATTER_API std::tuple<torch::Tensor, torch::Tensor>
 segment_max_csr(torch::Tensor src, torch::Tensor indptr,
-                torch::optional<torch::Tensor> optional_out);
+                std::optional<torch::Tensor> optional_out);
 
 SCATTER_API torch::Tensor
 gather_csr(torch::Tensor src, torch::Tensor indptr,
-           torch::optional<torch::Tensor> optional_out);
+           std::optional<torch::Tensor> optional_out);


### PR DESCRIPTION
Since Nov 29, 2023, PyTorch's `c10::optional` has been an alias for `std::optional` ([link](https://github.com/pytorch/pytorch/commit/165f4f6ccf7522d75df99c30821d583dfc58ad62)).

As of Dec 17, 2024, PyTorch  has begun taking steps to begin removing the `c10::optional` alias entirely ([link](https://github.com/pytorch/pytorch/commit/e2d47a133b928c1b11ae970ced760810bcd4bda4)). The old API remains available, for now, but you can check whether your code has eliminated all instances of deprecated APIs by compiling with `C10_NODEPRECATED` defined as a preprocessor flag (`-DC10_NODEPRECATED`).

This PR converts your existing usages of `c10::optional` to `std::optional` (same for `nullopt`).

(Additional deprecated APIs include `C10_UNUSED`, `C10_NODISCARD`, and `c10::string_view`.)