### PR TITLE
PyTorch 2.6. support

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -12,9 +12,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2019]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        torch-version: [2.5.0]  # [2.3.0, 2.4.0, 2.5.0]
+        torch-version: [2.6.0]  # [2.3.0, 2.4.0, 2.5.0, 2.6.0]
         cuda-version: ['cpu', 'cu118', 'cu121', 'cu124']
         exclude:
+          - torch-version: 2.6.0
+            python-version: '3.8'
+          - torch-version: 2.6.0
+            cuda-version: 'cu121'
           - torch-version: 2.5.0
             python-version: '3.8'
           - torch-version: 2.3.0

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.9]
-        torch-version: [2.4.0, 2.5.0]
+        torch-version: [2.4.0, 2.5.0, 2.6.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ conda install pytorch-scatter -c pyg
 
 We alternatively provide pip wheels for all major OS/PyTorch/CUDA combinations, see [here](https://data.pyg.org/whl).
 
+#### PyTorch 2.6
+
+To install the binaries for PyTorch 2.6.0, simply run
+
+```
+pip install torch-scatter -f https://data.pyg.org/whl/torch-2.6.0+${CUDA}.html
+```
+
+where `${CUDA}` should be replaced by either `cpu`, `cu118` or `cu124` depending on your PyTorch installation.
+
+|             | `cpu` | `cu118` | `cu124` |
+|-------------|-------|---------|---------|
+| **Linux**   | ✅    | ✅      | ✅      |
+| **Windows** | ✅    | ✅      | ✅      |
+| **macOS**   | ✅    |         |         |
+
 #### PyTorch 2.5
 
 To install the binaries for PyTorch 2.5.0, simply run


### PR DESCRIPTION
This PR introduces the changes to support PyTorch 2.6 versions.

## Development notes

- [x] PyTorch v2.6.0 is not available with CUDA 12.1 so the latter was removed from the workflow matrix
- [x] I was able to create the Linux wheels for python 3.10, 3.11 and 3.12 and CUDA 11.8 and 12.4