### PR TITLE
Add ROCm 6.4.3+ support

### DIFF
--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -6,13 +6,20 @@
   AT_ASSERTM(x.device().is_cuda(), #x " must be CUDA tensor")
 #define CHECK_INPUT(x) AT_ASSERTM(x, "Input mismatch")
 
-__device__ __inline__ at::Half __shfl_up_sync(const unsigned mask,
+// On ROCm, __shfl_*_sync requires a 64-bit mask; on CUDA it's 32-bit.
+#ifdef USE_ROCM
+  using warp_mask_t = unsigned long long;
+#else
+  using warp_mask_t = unsigned int;
+#endif
+
+__device__ __inline__ at::Half __shfl_up_sync(const warp_mask_t mask,
                                               const at::Half var,
                                               const unsigned int delta) {
   return __shfl_up_sync(mask, var.operator __half(), delta);
 }
 
-__device__ __inline__ at::Half __shfl_down_sync(const unsigned mask,
+__device__ __inline__ at::Half __shfl_down_sync(const warp_mask_t mask,
                                                 const at::Half var,
                                                 const unsigned int delta) {
   return __shfl_down_sync(mask, var.operator __half(), delta);


### PR DESCRIPTION
Because ROCm 6.4.3 implements stricter type checking in the HIP warp shuffle API, code that previously compiled in 6.4.2 now triggers a static_assert at compile time.

The error message reads:
static assertion failed due to requirement 'sizeof(unsigned int) == 8': The mask must be a 64-bit integer

This is because ROCm 6.4.3's __shfl_sync / __shfl_up_sync / __shfl_down_sync function templates now require the mask parameter to be a 64-bit integer (uint64_t), but your code is passing an unsigned int (32-bit), resulting in a compilation failure.

Reason for Change
In the HIP header file (amd_warp_sync_functions.h) of ROCm 6.4.3, AMD added the following:
static_assert(sizeof(MaskT) == 8, "The mask must be a 64-bit integer...");

This was added to unify the behavior and avoid potential errors caused by implicit type promotion.