### PR TITLE
Detect ROCm builds without requiring a visible GPU

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,12 @@ __version__ = '2.1.2'
 URL = 'https://github.com/rusty1s/pytorch_scatter'
 
 WITH_CUDA = False
-if torch.cuda.is_available():
-    WITH_CUDA = CUDA_HOME is not None or torch.version.hip
+if torch.version.hip is not None:
+    # A ROCm build of PyTorch always targets HIP, and no GPU needs to be
+    # visible at build time (e.g. when building wheels on a CI runner):
+    WITH_CUDA = True
+elif torch.cuda.is_available():
+    WITH_CUDA = CUDA_HOME is not None
 suffices = ['cpu', 'cuda'] if WITH_CUDA else ['cpu']
 if os.getenv('FORCE_CUDA', '0') == '1':
     suffices = ['cuda', 'cpu']
@@ -119,7 +123,7 @@ test_requires = [
 
 # work-around hipify abs paths
 include_package_data = True
-if torch.cuda.is_available() and torch.version.hip:
+if torch.version.hip is not None:
     include_package_data = False
 
 setup(


### PR DESCRIPTION
`setup.py` gates the HIP extension build on `torch.cuda.is_available()`, which is `False` on any machine without a visible GPU — including CI wheel builders. On a ROCm build of PyTorch that silently produces a CPU-only wheel, and it also skips the `include_package_data` work-around that's there specifically for hipify's absolute paths.

Both checks now key off `torch.version.hip`, which describes the PyTorch build rather than the machine doing the building. CUDA behaviour is unchanged.

Tested on ROCm 7.2 / gfx1150 with PyTorch 2.13: builds from source and the test suite passes (2771 passed, 30 skipped — the skips are all multi-GPU).
